### PR TITLE
Fix credentials cache issue

### DIFF
--- a/src/Orc.NuGetExplorer.Tests/Services/CredentialsKeyHelperFacts.cs
+++ b/src/Orc.NuGetExplorer.Tests/Services/CredentialsKeyHelperFacts.cs
@@ -1,0 +1,37 @@
+﻿namespace Orc.NuGetExplorer.Tests.Services
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NuGet.Configuration;
+    using NuGet.Credentials;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CredentialsKeyHelperFacts
+    {
+        [TestCase("https://api.nuget.org/v3/index.json", "https://api.nuget.org/v3/")]
+        [TestCase("https://extensions.wildgums.com/sub-url/nuget/index.json", "https://extensions.wildgums.com/sub-url/nuget/")]
+        [TestCase("https://extensions.wildgums.com/another-sub-url/nuget/index.json", "https://extensions.wildgums.com/another-sub-url/nuget/")]
+        public void ReturnsCorrectCacheKey(string url, string expectedUrlPart)
+        {
+            var uri = new Uri(url, UriKind.RelativeOrAbsolute);
+
+            var actual = ExplorerCredentialService.CredentialsKeyHelper.GetUriKey(uri, NuGet.Configuration.CredentialRequestType.Forbidden, new DummyCredentialsProvider());
+            var expected = $"dummy_{false}_{expectedUrlPart}";
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+
+    public class DummyCredentialsProvider : ICredentialProvider
+    {
+        public string Id => "dummy";
+
+        public Task<CredentialResponse> GetAsync(Uri uri, IWebProxy proxy, CredentialRequestType type, string message, bool isRetry, bool nonInteractive, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Orc.NuGetExplorer.Tests/Services/CredentialsKeyHelperFacts.cs
+++ b/src/Orc.NuGetExplorer.Tests/Services/CredentialsKeyHelperFacts.cs
@@ -18,7 +18,7 @@
         {
             var uri = new Uri(url, UriKind.RelativeOrAbsolute);
 
-            var actual = ExplorerCredentialService.CredentialsKeyHelper.GetUriKey(uri, NuGet.Configuration.CredentialRequestType.Forbidden, new DummyCredentialsProvider());
+            var actual = ExplorerCredentialService.CredentialsKeyHelper.GetCacheKey(uri, NuGet.Configuration.CredentialRequestType.Forbidden, new DummyCredentialsProvider());
             var expected = $"dummy_{false}_{expectedUrlPart}";
 
             Assert.AreEqual(expected, actual);

--- a/src/Orc.NuGetExplorer/Services/CredentialProviderLoaderService.cs
+++ b/src/Orc.NuGetExplorer/Services/CredentialProviderLoaderService.cs
@@ -36,6 +36,7 @@
         public void SetCredentialPolicy(CredentialStoragePolicy storagePolicy)
         {
             Log.Info($"Changing credential storage policy to {storagePolicy}");
+
             _configurationService.SetCredentialStoragePolicy(storagePolicy);
         }
 

--- a/src/Orc.NuGetExplorer/Services/ExplorerCredentialService.cs
+++ b/src/Orc.NuGetExplorer/Services/ExplorerCredentialService.cs
@@ -29,7 +29,7 @@
         /// </summary>
         private AsyncLazy<IEnumerable<ICredentialProvider>> _providers { get; }
 
-        private readonly Semaphore _proivderSemaphore = new Semaphore(1, 1);
+        private readonly Semaphore _providerSemaphore = new Semaphore(1, 1);
 
         public bool HandlesDefaultCredentials { get; }
 
@@ -96,13 +96,11 @@
                     //in fact unecessary, because service called
                     //only when no one provider cached
 
-                    _proivderSemaphore.WaitOne();
-
-                    CredentialResponse response;
+                    _providerSemaphore.WaitOne();
 
                     Log.Debug($"Requesting credentials, _retryCache count = {_retryCache.Count}");
 
-                    if (!TryFromCredentialCache(uri, type, isRetry, provider, out response))
+                    if (!TryFromCredentialCache(uri, type, isRetry, provider, out var response))
                     {
                         response = await provider.GetAsync(
                             uri,
@@ -144,7 +142,7 @@
                 }
                 finally
                 {
-                    _proivderSemaphore.Release();
+                    _providerSemaphore.Release();
                 }
             }
 
@@ -230,13 +228,16 @@
             Log.Debug($"_retryCache count {_retryCache.Count}");
         }
 
-        private static class CredentialsKeyHelper
+        internal static class CredentialsKeyHelper
         {
             public static string GetCacheKey(Uri uri, CredentialRequestType type, ICredentialProvider provider)
             {
+                // Note: don't cache by root uri, just remove catalog info
+
                 var rootUri = uri.GetRootUri();
                 return GetUriKey(rootUri, type, provider);
             }
+
             public static string GetUriKey(Uri uri, CredentialRequestType type, ICredentialProvider provider)
             {
                 return $"{provider.Id}_{type == CredentialRequestType.Proxy}_{uri}";

--- a/src/Orc.NuGetExplorer/Services/ExplorerCredentialService.cs
+++ b/src/Orc.NuGetExplorer/Services/ExplorerCredentialService.cs
@@ -233,9 +233,17 @@
             public static string GetCacheKey(Uri uri, CredentialRequestType type, ICredentialProvider provider)
             {
                 // Note: don't cache by root uri, just remove catalog info
+                //var rootUri = uri.GetRootUri();
 
-                var rootUri = uri.GetRootUri();
-                return GetUriKey(rootUri, type, provider);
+                const string IndexName = "index.json";
+
+                var rootUrl = uri.ToString();
+                if (rootUrl.EndsWithIgnoreCase(IndexName))
+                {
+                    rootUrl = rootUrl.Substring(0, rootUrl.Length - IndexName.Length);
+                }
+
+                return GetUriKey(new Uri(rootUrl, UriKind.RelativeOrAbsolute), type, provider);
             }
 
             public static string GetUriKey(Uri uri, CredentialRequestType type, ICredentialProvider provider)


### PR DESCRIPTION
This issue makes it impossible to provide different credentials for different feeds on the same subdomain, e.g.:

- https://extensions.wildgums.com/sub-url/nuget/index.json
- https://extensions.wildgums.com/another-sub-url/nuget/index.json