### PR TITLE
Feature/Feeds-settings-improvements

### DIFF
--- a/src/Orc.NuGetExplorer.Tests/Orc.NuGetExplorer.approved.cs
+++ b/src/Orc.NuGetExplorer.Tests/Orc.NuGetExplorer.approved.cs
@@ -67,6 +67,7 @@ namespace Orc.NuGetExplorer
     public class DefaultNuGetFramework : Orc.NuGetExplorer.IDefaultNuGetFramework
     {
         public DefaultNuGetFramework(NuGet.Frameworks.IFrameworkNameProvider frameworkNameProvider) { }
+        public NuGet.Frameworks.NuGetFramework GetFirst() { }
         public System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> GetHighest() { }
         public System.Collections.Generic.IEnumerable<NuGet.Frameworks.NuGetFramework> GetLowest() { }
     }

--- a/src/Orc.NuGetExplorer.Xaml/ViewModels/FeedDetailViewModel.cs
+++ b/src/Orc.NuGetExplorer.Xaml/ViewModels/FeedDetailViewModel.cs
@@ -21,17 +21,6 @@
         [ViewModelToModel]
         public string Source { get; set; }
 
-        private void UpdateFeed()
-        {
-            if (!IsInitialized || Feed is null)
-            {
-                return;
-            }
-
-            // manually save model and pass forward
-            Feed.ForceEndEdit();
-        }
-
         public Command OpenChooseLocalPathToSourceDialog { get; set; }
 
         private void OnOpenChooseLocalPathToSourceDialogExecute()

--- a/src/Orc.NuGetExplorer.Xaml/ViewModels/PackageSourceSettingViewModel.cs
+++ b/src/Orc.NuGetExplorer.Xaml/ViewModels/PackageSourceSettingViewModel.cs
@@ -145,6 +145,9 @@
         {
             ValidationTimer.Elapsed += OnValidationTimerElapsed;
             Feeds.CollectionChanged += OnFeedsCollectionChanged;
+
+            // Enforce subscription, validation etc on feeds
+            HandleFeedCollectionChanges(Feeds);
         }
 
         protected override async Task<bool> SaveAsync()
@@ -328,8 +331,11 @@
                 return;
             }
 
-            var newFeeds = e.NewItems.OfType<NuGetFeed>().ToList();
+            HandleFeedCollectionChanges(e.NewItems.OfType<NuGetFeed>().ToList());
+        }
 
+        private void HandleFeedCollectionChanges(ICollection<NuGetFeed> newFeeds)
+        {
             SelectedFeed = newFeeds.LastOrDefault();
 
             foreach (var item in newFeeds)

--- a/src/Orc.NuGetExplorer.Xaml/ViewModels/PackageSourceSettingViewModel.cs
+++ b/src/Orc.NuGetExplorer.Xaml/ViewModels/PackageSourceSettingViewModel.cs
@@ -189,6 +189,10 @@
             SettingsFeeds.AddRange(Feeds);
 
             _configurationService.SavePackageSources(Feeds);
+            foreach(var feed in RemovedFeeds)
+            {
+                _configurationService.RemovePackageSource(feed);
+            }
         }
 
         private bool IsNamesNotUniqueRule(out IEnumerable<string> invalidNames)

--- a/src/Orc.NuGetExplorer.Xaml/Views/FeedDetailView.xaml
+++ b/src/Orc.NuGetExplorer.Xaml/Views/FeedDetailView.xaml
@@ -34,7 +34,7 @@
                  Margin="4 4 2 0"
                  VerticalAlignment="Top" 
                  IsEnabled="{Binding Path=., Converter={catel:ReferenceToBooleanConverter}}"
-                 Text="{Binding Name}">
+                 Text="{Binding Name, ValidatesOnDataErrors=True, NotifyOnValidationError=True}">
             <xamlbehaviors:Interaction.Behaviors>
                 <catel:UpdateBindingOnTextChanged UpdateDelay="500"/>
             </xamlbehaviors:Interaction.Behaviors>
@@ -52,7 +52,7 @@
                  Margin="4 4 2 0"
                  VerticalAlignment="Top" 
                  IsEnabled="{Binding Path=., Converter={catel:ReferenceToBooleanConverter}}"
-                 Text="{Binding Source}">
+                 Text="{Binding Source, ValidatesOnDataErrors=True, NotifyOnValidationError=True}">
             <xamlbehaviors:Interaction.Behaviors>
                 <catel:UpdateBindingOnTextChanged UpdateDelay="500"/>
             </xamlbehaviors:Interaction.Behaviors>

--- a/src/Orc.NuGetExplorer/Configuration/NuGetSettings.cs
+++ b/src/Orc.NuGetExplorer/Configuration/NuGetSettings.cs
@@ -206,7 +206,8 @@
 
             RaiseSettingsRead();
 
-            return new NuGetSettingsSection(sectionName, subsections);
+            var section = new NuGetSettingsSection(sectionName, subsections);
+            return section;
         }
 
         public void AddOrUpdate(string sectionName, SettingItem item)
@@ -239,7 +240,8 @@
 
         public void SaveToDisk()
         {
-            //should flush in-memory updates in file, but currently all changes saved manually instant in configuration file via Catel Configuration
+            // Note: Implementations of ISettings designed assuming that all updates are storing in-memory and flushed to disk file only on call of SaveToDisk()
+            // Here we are using Catel's configuration and saving all changes instantly, thats why implementation of this method is empty
             Log.Debug("SaveToDisk method called from PackageSourceProvider");
         }
 

--- a/src/Orc.NuGetExplorer/Configuration/NuGetSettings.cs
+++ b/src/Orc.NuGetExplorer/Configuration/NuGetSettings.cs
@@ -269,7 +269,7 @@
             EnsureSectionExists(section);
 
             var valuesListKey = GetSectionValuesListKey(section);
-            UpdateKeysList(values, valuesListKey);
+            UpdateKeyList(values, valuesListKey);
 
             foreach (var item in values)
             {
@@ -300,14 +300,14 @@
             EnsureSectionExists(section);
 
             var valuesListKey = GetSubsectionValuesListKey(section, subsection);
-            UpdateKeysList(values, valuesListKey);
+            UpdateKeyList(values, valuesListKey);
             foreach (var keyValuePair in values)
             {
                 SetNuGetValue(section, subsection, keyValuePair.Key, keyValuePair.Value);
             }
         }
 
-        private void UpdateKeysList(IList<AddItem> values, string valuesListKey)
+        private void UpdateKeyList(IList<AddItem> values, string valuesListKey)
         {
             var valueKeysString = _configurationService.GetRoamingValue<string>(valuesListKey);
             var existedKeys = string.IsNullOrEmpty(valueKeysString) ? Enumerable.Empty<string>() : valueKeysString.Split(Separator);
@@ -315,6 +315,15 @@
 
             var newValueKeysString = string.Join(Separator.ToString(), existedKeys.Union(keysToSave));
             _configurationService.SetRoamingValue(valuesListKey, newValueKeysString);
+        }
+
+        public void UpdatePackageSourcesKeyListSorting(List<string> packageSourceNames)
+        {
+            var packageSourcesKeyListKey = GetSectionValuesListKey(ConfigurationConstants.PackageSources);
+            var enabledPackageSourcesKeys = _configurationService.GetRoamingValue<string>(packageSourcesKeyListKey).Split(Separator);
+            var sortedKeys = enabledPackageSourcesKeys.OrderBy(key => packageSourceNames.IndexOf(key));
+            var sortedKeysStringValue = string.Join(Separator, sortedKeys);
+            _configurationService.SetRoamingValue(packageSourcesKeyListKey, sortedKeysStringValue);
         }
 
         private string ConvertToFullPath(string result)

--- a/src/Orc.NuGetExplorer/Models/NugetFeed.cs
+++ b/src/Orc.NuGetExplorer/Models/NugetFeed.cs
@@ -131,10 +131,7 @@
 
             if (string.IsNullOrEmpty(error))
             {
-                if (_propertyNameToDataError.ContainsKey(propertyName))
-                {
-                    _propertyNameToDataError.Remove(propertyName);
-                }
+                _propertyNameToDataError.Remove(propertyName);
             }
             else
             {

--- a/src/Orc.NuGetExplorer/Models/NugetFeed.cs
+++ b/src/Orc.NuGetExplorer/Models/NugetFeed.cs
@@ -107,7 +107,12 @@
                 return Enumerable.Empty<string>();
             }
 
-            return _propertyNameToDataError.ContainsKey(propertyName) ? new[] { _propertyNameToDataError[propertyName] } : Enumerable.Empty<string>();
+            if (_propertyNameToDataError.TryGetValue(propertyName, out var error))
+            {
+                return new[] { error };
+            }
+
+            return Enumerable.Empty<string>();
         }
 
         private void RaiseErrorsChanged(string propertyName)
@@ -117,6 +122,8 @@
 
         private void ValidateAndRaiseErrorsChanged(string propertyName)
         {
+            _propertyNameToDataError.Clear();
+
             var error = this[propertyName];
 
             if (!_propertyNameToDataError.TryGetValue(propertyName, out string oldError))
@@ -129,7 +136,7 @@
                 _propertyNameToDataError[propertyName] = error;
             }
 
-            if (string.Equals(error, oldError))
+            if (!string.Equals(error, oldError))
             {
                 RaiseErrorsChanged(propertyName);
             }
@@ -171,7 +178,7 @@
             }
             catch (UriFormatException)
             {
-                Error = "Incorrect feed source can`t be recognized as Uri";
+                // Error = "Incorrect feed source can`t be recognized as Uri";
                 return null;
             }
         }
@@ -190,7 +197,6 @@
                 SerializationIdentifier = SerializationIdentifier
             };
         }
-
 
         protected override void OnPropertyChanged(AdvancedPropertyChangedEventArgs e)
         {

--- a/src/Orc.NuGetExplorer/Models/NugetFeed.cs
+++ b/src/Orc.NuGetExplorer/Models/NugetFeed.cs
@@ -122,16 +122,21 @@
 
         private void ValidateAndRaiseErrorsChanged(string propertyName)
         {
-            _propertyNameToDataError.Clear();
-
             var error = this[propertyName];
 
-            if (!_propertyNameToDataError.TryGetValue(propertyName, out string oldError))
+            if (!_propertyNameToDataError.TryGetValue(propertyName, out var oldError))
             {
                 oldError = string.Empty;
             }
 
-            if (!string.IsNullOrEmpty(error))
+            if (string.IsNullOrEmpty(error))
+            {
+                if (_propertyNameToDataError.ContainsKey(propertyName))
+                {
+                    _propertyNameToDataError.Remove(propertyName);
+                }
+            }
+            else
             {
                 _propertyNameToDataError[propertyName] = error;
             }

--- a/src/Orc.NuGetExplorer/Providers/NuGetPackageSourceProvider.cs
+++ b/src/Orc.NuGetExplorer/Providers/NuGetPackageSourceProvider.cs
@@ -7,16 +7,36 @@
 
 namespace Orc.NuGetExplorer
 {
+    using System.Collections.Generic;
+    using Catel;
+    using Catel.Logging;
     using NuGet.Configuration;
+    using Orc.NuGetExplorer.Configuration;
 
     internal class NuGetPackageSourceProvider : PackageSourceProvider
     {
-        #region Constructors
+        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+        private readonly ISettings _settingsManager;
+
         public NuGetPackageSourceProvider(ISettings settingsManager, IDefaultPackageSourcesProvider defaultPackageSourcesProvider)
             : base(settingsManager, defaultPackageSourcesProvider.GetDefaultPackages().ToPackageSourceInstances())
         {
+            Argument.IsNotNull(() => settingsManager);
+            Argument.IsNotNull(() => defaultPackageSourcesProvider);
+
+            _settingsManager = settingsManager;
         }
 
-        #endregion
+        public void SortPackageSources(List<string> packageSourceNames)
+        {
+            if (_settingsManager is NuGetSettings nugetSettings)
+            {
+                nugetSettings.UpdatePackageSourcesKeyListSorting(packageSourceNames);
+            }
+            else
+            {
+                Log.Debug($"Sorting operation for NuGet Settings source of type {_settingsManager.GetType()} is not implemented");
+            }
+        }
     }
 }

--- a/src/Orc.NuGetExplorer/Services/NuGetConfigurationService.cs
+++ b/src/Orc.NuGetExplorer/Services/NuGetConfigurationService.cs
@@ -118,6 +118,11 @@
         {
             Argument.IsNotNull(() => packageSources);
             _packageSourceProvider.Value.SavePackageSources(packageSources.ToPackageSourceInstances());
+
+            if (_packageSourceProvider.Value is NuGetPackageSourceProvider nugetPackageSourceProvider)
+            {
+                nugetPackageSourceProvider.SortPackageSources(packageSources.Select(x => x.Name).ToList());
+            }
         }
 
         public void SetIsPrereleaseAllowed(IRepository repository, bool value)

--- a/src/Orc.NuGetExplorer/Services/NuGetConfigurationService.cs
+++ b/src/Orc.NuGetExplorer/Services/NuGetConfigurationService.cs
@@ -21,7 +21,7 @@
         private readonly string _defaultDestinationFolder;
         private int _packageQuerySize = 40;
 
-        //had to doing this, because settings is as parameter in ctor caused loop references
+        // Note: Lazy allows to avoid circular types resolving if construct from TypeFactory
         private readonly Lazy<IPackageSourceProvider> _packageSourceProvider = new Lazy<IPackageSourceProvider>(
                 () =>
                 {
@@ -111,7 +111,7 @@
 
         public void RemovePackageSource(IPackageSource source)
         {
-            //todo implement packageSource removal
+            _packageSourceProvider.Value.RemovePackageSource(source.Name);
         }
 
         public void SavePackageSources(IEnumerable<IPackageSource> packageSources)


### PR DESCRIPTION
### Description of Change ###

- Fixed sorting wasn't saved for feeds
- Fixed various problems with validation updates (ORCOMP-576)
- Fixed feed not removed from configuration after moving on current version of NuGet lib (CHAM-229)

### Issues Resolved ### 

- fixes CHAM-229
- fixes ORCOMP-576

### API Changes ###
 
None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All


### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
